### PR TITLE
exclude files from github export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/copy-from-pear-core.sh export-ignore


### PR DESCRIPTION
this will skip those files on composer based installs who do `--prefer-dist`
