### PR TITLE
Fix PHP 7.4 deprecation: array/string curly braces access

### DIFF
--- a/src/OS/Guess.php
+++ b/src/OS/Guess.php
@@ -240,7 +240,7 @@ class OS_Guess
             fclose($fp);
             $cpp = popen("/usr/bin/cpp $tmpfile", "r");
             while ($line = fgets($cpp, 1024)) {
-                if ($line{0} == '#' || trim($line) == '') {
+                if ($line[0] == '#' || trim($line) == '') {
                     continue;
                 }
 

--- a/src/System.php
+++ b/src/System.php
@@ -74,7 +74,7 @@ class System
             $offset = 0;
             foreach ($av as $a) {
                 $b = trim($a[0]);
-                if ($b{0} == '"' || $b{0} == "'") {
+                if ($b[0] == '"' || $b[0] == "'") {
                     continue;
                 }
 


### PR DESCRIPTION
Deprecated: Array and string offset access syntax with curly braces is deprecated

Hopefully these are all (or most) of them:
```
[Clover@Clover-NB rc]$ rg -tphp "(\\$|->|::)[A-Za-z0-9_]+\{"
vendor\pear\pear-core-minimal\src\System.php:77:                if ($b{0} == '"' || $b{0} == "'") {
vendor\pear\pear-core-minimal\src\OS\Guess.php:243:                if ($line{0} == '#' || trim($line) == '') {
```

https://github.com/php/php-src/blob/0e6e2297fcb27103cc5d550ee8434680ff1e879e/UPGRADING#L356-L357
