### PR TITLE
Fix PHP 7.4+ deprecation warning

### DIFF
--- a/src/System.php
+++ b/src/System.php
@@ -265,7 +265,7 @@ class System
             } elseif ($opt[0] == 'm') {
                 // if the mode is clearly an octal number (starts with 0)
                 // convert it to decimal
-                if (strlen($opt[1]) && $opt[1]{0} == '0') {
+                if (strlen($opt[1]) && $opt[1][0] == '0') {
                     $opt[1] = octdec($opt[1]);
                 } else {
                     // convert to int


### PR DESCRIPTION
> "Array and string offset access syntax with curly braces is deprecated"

I'm not entirely sure this is the only one, but that's what I'm getting for https://github.com/pear/OLE/pull/19 builds.

See also https://github.com/pear/pear-core/pull/97