### PR TITLE
Require PHP version with sys_get_temp_dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     },
     "type": "library",
     "require": {
+        "php": ">=5.2.1",
         "pear/console_getopt": "~1.4",
         "pear/pear_exception": "~1.0"
     },


### PR DESCRIPTION
#6 introduced use of `sys_get_temp_dir`, for a valid reason. But there isn't any constrains on PHP version, where `sys_get_temp_dir` may not be available in older versions. This PR adds a minimal requirement for the PHP version.