### PR TITLE
Deprecations for PHP 8.1

### DIFF
--- a/src/PEAR.php
+++ b/src/PEAR.php
@@ -219,7 +219,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(self::class, '_' . $method),
             array_merge(array($this), $arguments)
         );
     }
@@ -232,7 +232,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(self::class, '_' . $method),
             array_merge(array(null), $arguments)
         );
     }


### PR DESCRIPTION
In scope of PHP8.1 compatibility static analysis it was discovered some deprecations in webflo/drupal-finder codebase: 
- line 222 vendor/pear/pear-core-minimal/src/PEAR.php get_class() without argument (tag 1.10.11)
-  line 235 vendor/pear/pear-core-minimal/src/PEAR.php get_class() without argument (tag 1.10.11)