### PR TITLE
Avoid calling `get_class()` without arguments

### DIFF
--- a/src/PEAR.php
+++ b/src/PEAR.php
@@ -219,7 +219,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(__CLASS__, '_' . $method),
             array_merge(array($this), $arguments)
         );
     }
@@ -232,7 +232,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(__CLASS__, '_' . $method),
             array_merge(array(null), $arguments)
         );
     }


### PR DESCRIPTION
This is deprecated in PHP 8.3, see https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated.

Fixes #16.